### PR TITLE
pointers only used in results, not in input structs

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -71,6 +71,13 @@ type ServiceAccountInput struct {
 	SubjectId string `json:"subjectId"`
 }
 
+type ServiceAccount struct {
+	ID                          string `json:"id"`
+	KubeConfig                  string `json:"kubeConfig"`
+	ServiceAccountToken         string `json:"serviceAccountToken"`
+	ClusterCertificateAuthority string `json:"clusterCertificateAuthority"`
+}
+
 type ClusterIdentity struct {
 	CertificatePem                 string `json:"certificatePem"`
 	PrivateKeyPem                  string `json:"privateKeyPem"`
@@ -169,13 +176,6 @@ func (c *ClusterServiceClient) ListNodes(clusterName string) (*NodeList, error) 
 	}
 
 	return nodeList, nil
-}
-
-type ServiceAccount struct {
-	ID                          string `json:"id"`
-	KubeConfig                  string `json:"kubeConfig"`
-	ServiceAccountToken         string `json:"serviceAccountToken"`
-	ClusterCertificateAuthority string `json:"clusterCertificateAuthority"`
 }
 
 func (c *ClusterServiceClient) CreateServiceAccountForSelf(clusterName string) (*ServiceAccount, error) {

--- a/node_pool.go
+++ b/node_pool.go
@@ -25,8 +25,8 @@ type NodePool struct {
 	NodeTypeName    string              `json:"nodeTypeName"`
 	ClusterName     string              `json:"clusterName"`
 	DesiredQuantity int                 `json:"desiredQuantity"`
-	Labels          []NodeLabel         `json:"labels"`
-	Taints          []NodeTaint         `json:"taints"`
+	Labels          []*NodeLabel        `json:"labels"`
+	Taints          []*NodeTaint        `json:"taints"`
 	Nodes           []*Node             `json:"nodes"`
 	Autoscaling     AutoscalingSettings `json:"autoscaling"`
 }
@@ -51,8 +51,8 @@ type NodePoolInput struct {
 	ClusterName  string              `json:"clusterName"`
 	NodeTypeName string              `json:"nodeTypeName"`
 	Quantity     int                 `json:"quantity"`
-	Labels       []*NodeLabel        `json:"labels"`
-	Taints       []*NodeTaint        `json:"taints"`
+	Labels       []NodeLabel         `json:"labels"`
+	Taints       []NodeTaint         `json:"taints"`
 	Autoscaling  AutoscalingSettings `json:"autoscaling"`
 }
 


### PR DESCRIPTION
Little bit of refactoring before fully releasing new Terraform provider

* Structs that are returned by API responses are now all pointers
* Input structs are no longer pointers when passed to other structs.